### PR TITLE
Run CI on main and on stacked pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,16 @@
 name: Code checking and unit testing
 
 on:
-  pull_request:
+  # main was never tested directly: the only trigger was a pull request, so
+  # anything that reached main by another route — a merge whose checks had not
+  # finished, a direct push — went unverified.
+  push:
     branches: [ main ]
+  # No branch filter. Restricting to `branches: [main]` skipped every stacked
+  # pull request, because a PR based on another feature branch does not match.
+  # Those are exactly the changes that most want checking before the base lands.
+  pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Follow-up to #22/#23, which both merged **without a single check run**. This closes the two gaps that allowed it.

## What went wrong

`rust.yml` triggered only on `pull_request` with `branches: [main]`.

1. **`main` is never tested.** There is no `push` trigger, so anything reaching `main` by another route is unverified. The run history shows `Code checking and unit testing` firing for `modernize-example-app` (#21) and then nothing for #22 or #23 — the pushes to `main` only triggered the Pages deploy.
2. **Stacked PRs get no checks.** A PR based on another feature branch doesn't match `branches: [main]`. #22 was based on `modernize-example-app` and #23 on `dwind-keyframes-and-arbitrary-values`, so neither ever qualified. They were retargeted to `main` shortly before merge, which is too late for checks to run.

The changes that most want verifying are the stacked ones, since they land on top of an unmerged base.

## The change

```yaml
on:
  push:
    branches: [ main ]
  pull_request:
  workflow_dispatch:
```

`push` stays pinned to `main`, so a PR branch in this repo doesn't run twice. `workflow_dispatch` means `main` can be re-checked on demand instead of needing a throwaway PR.

## Verification

The workflow was run locally against merged `main`, reproducing all four steps:

| step | result |
|---|---|
| `cargo test` (host) | pass |
| `cargo clippy` | pass |
| wasm suite, Firefox | pass |
| wasm suite, Chrome | pass |

Two notes from doing that, both worth knowing for anyone reproducing CI locally:

- It needs `wasm-bindgen-cli` **0.2.105** to match `Cargo.lock`. A newer global install fails with a bindgen schema mismatch — which is exactly what the existing comment on the `wasm-bindgen-action` version pin is warning about. `wasm-pack test` masks this by managing its own matching copy, so the bare `cargo test --target wasm32-unknown-unknown` that CI runs is the stricter check.
- The Chrome leg needs a ChromeDriver matching the installed Chrome (149 here).

This PR is itself the first test of the new trigger: opening it should produce a check run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)