### PR TITLE
Remove a stray trunk log and ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea
 dist
+
+# Local build/serve logs
+*.log

--- a/examples/webpage/trunk2.log
+++ b/examples/webpage/trunk2.log
@@ -1,2 +1,0 @@
-2026-07-26T08:43:47.810182Z  INFO 🚀 Starting trunk 0.21.14
-2026-07-26T08:43:47.810368Z ERROR Unable to find any Trunk configuration


### PR DESCRIPTION
A `trunk serve` redirect got committed by accident in the dwui overhaul merge. Nothing reads it, and `.gitignore` now covers `*.log`.

Doing this before tagging the release so the tag points at a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)