### PR TITLE
Adopt component macro 0.5.0: required props, Into setters, composed apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,7 @@ dependencies = [
 
 [[package]]
 name = "futures-signals-component-macro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f880902471275d8da2913632c5e794e6bee9e846bf29fddec1cbd7e3c105675c"
+version = "0.5.0"
 dependencies = [
  "convert_case",
  "dominator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cssparser = "0.34"
 dominator = "0.5"
 futures = "0.3"
 futures-signals = "0.3"
-futures-signals-component-macro = { version = "0.4.0", features = [
+futures-signals-component-macro = { version = "0.5.0", features = [
     "dominator",
 ] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
@@ -63,3 +63,8 @@ debug = "line-tables-only"
 
 [profile.test]
 debug = "line-tables-only"
+
+# Temporary while developing futures-signals-component-macro 0.5.0; drop once
+# it is published to crates.io.
+[patch.crates-io]
+futures-signals-component-macro = { path = "../../gui/futures-signals-component-macro" }

--- a/crates/dwui/src/components/containers/card.rs
+++ b/crates/dwui/src/components/containers/card.rs
@@ -1,7 +1,7 @@
 use crate::theme::prelude::*;
 use dominator::{html, Dom};
 use dwind::prelude::*;
-use futures_signals::signal::{option, SignalExt};
+use futures_signals::signal::SignalExt;
 use futures_signals_component_macro::component;
 
 /// Dictates the color scheme of the component
@@ -23,6 +23,7 @@ pub enum CardPadding {
 #[component(render_fn = card)]
 struct Card {
     #[signal]
+    #[required]
     content: Dom,
 
     #[signal]
@@ -56,6 +57,6 @@ pub fn card(props: CardProps) -> Dom {
         .dwclass_signal!("p-4", padding.signal().map(|v| v == CardPadding::Medium))
         .dwclass_signal!("p-6", padding.signal().map(|v| v == CardPadding::Large))
         .apply_if(apply.is_some(), |b| b.apply(apply.unwrap()))
-        .child_signal(option(content))
+        .child_signal(content.map(Some))
     })
 }

--- a/crates/dwui/src/components/content/avatar.rs
+++ b/crates/dwui/src/components/content/avatar.rs
@@ -27,11 +27,13 @@ struct Avatar {
     /// Image URL; when `None`, initials derived from `name` are shown
     #[signal]
     #[default(None)]
+    #[into]
     src: Option<String>,
 
     /// Display name; used for the `alt` text and initials fallback
     #[signal]
     #[default("".to_string())]
+    #[into]
     name: String,
 
     #[signal]

--- a/crates/dwui/src/components/content/divider.rs
+++ b/crates/dwui/src/components/content/divider.rs
@@ -9,6 +9,7 @@ use futures_signals_component_macro::component;
 struct Divider {
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 }
 

--- a/crates/dwui/src/components/content/heading.rs
+++ b/crates/dwui/src/components/content/heading.rs
@@ -1,7 +1,7 @@
 use crate::theme::prelude::*;
 use dominator::{html, Dom};
 use dwind::prelude::*;
-use futures_signals::signal::{option, SignalExt};
+use futures_signals::signal::SignalExt;
 use futures_signals_component_macro::component;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -58,6 +58,7 @@ impl HeadingLevel {
 #[component(render_fn = heading)]
 struct Heading {
     #[signal]
+    #[required]
     content: Dom,
 
     #[signal]
@@ -85,6 +86,6 @@ pub fn heading(props: HeadingProps) -> Dom {
         .dwclass!("w-auto font-semibold m-0")
         .dwclass!("dwui-text-on-primary-100 is(.light *):dwui-text-on-primary-900")
         .apply_if(apply.is_some(), |b| b.apply(apply.unwrap()))
-        .child_signal(option(content))
+        .child_signal(content.map(Some))
     })
 }

--- a/crates/dwui/src/components/content/list.rs
+++ b/crates/dwui/src/components/content/list.rs
@@ -15,6 +15,7 @@ struct List {
 
     #[signal]
     #[default(None)]
+    #[into]
     selected_index: Option<usize>,
 
     #[default(Box::new(|_|{}))]

--- a/crates/dwui/src/components/content/virtual_scroll.rs
+++ b/crates/dwui/src/components/content/virtual_scroll.rs
@@ -37,7 +37,7 @@ struct VirtualScroll {
     #[default(400.0)]
     height: f64,
 
-    #[default(Box::new(|_| html!("div")))]
+    #[required]
     render_item: dyn Fn(usize) -> Dom + 'static,
 
     #[default(Box::new(|| {}))]
@@ -50,6 +50,7 @@ struct VirtualScroll {
     /// Accessible name for the list
     #[signal]
     #[default("List".to_string())]
+    #[into]
     aria_label: String,
 }
 
@@ -174,7 +175,7 @@ pub fn virtual_scroll(props: VirtualScrollProps) -> Dom {
                         .child(spinner(
                             SpinnerProps::new()
                                 .size(SpinnerSize::Small)
-                                .label("Loading more".to_string()),
+                                .label("Loading more"),
                         ))
                     })
                 })

--- a/crates/dwui/src/components/input/checkbox.rs
+++ b/crates/dwui/src/components/input/checkbox.rs
@@ -23,6 +23,7 @@ struct Checkbox {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[default(Box::new(|_| {}))]

--- a/crates/dwui/src/components/input/date_picker.rs
+++ b/crates/dwui/src/components/input/date_picker.rs
@@ -25,6 +25,7 @@ struct DatePicker {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/input/number_input.rs
+++ b/crates/dwui/src/components/input/number_input.rs
@@ -29,14 +29,17 @@ struct NumberInput {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]
     #[default(None)]
+    #[into]
     min: Option<f64>,
 
     #[signal]
     #[default(None)]
+    #[into]
     max: Option<f64>,
 
     #[signal]

--- a/crates/dwui/src/components/input/radio_group.rs
+++ b/crates/dwui/src/components/input/radio_group.rs
@@ -29,6 +29,7 @@ struct RadioGroup {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     value: String,
 
     #[default(Box::new(|_|{}))]
@@ -37,6 +38,7 @@ struct RadioGroup {
     /// Visible group label
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/input/select.rs
+++ b/crates/dwui/src/components/input/select.rs
@@ -20,6 +20,7 @@ struct Select {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/input/slider.rs
+++ b/crates/dwui/src/components/input/slider.rs
@@ -30,6 +30,7 @@ struct Slider {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/input/switch.rs
+++ b/crates/dwui/src/components/input/switch.rs
@@ -23,6 +23,7 @@ struct Switch {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[default(Box::new(|_| {}))]

--- a/crates/dwui/src/components/input/text_area.rs
+++ b/crates/dwui/src/components/input/text_area.rs
@@ -30,6 +30,7 @@ struct TextArea {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/input/text_input.rs
+++ b/crates/dwui/src/components/input/text_input.rs
@@ -26,6 +26,7 @@ struct TextInput {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     label: String,
 
     #[signal]

--- a/crates/dwui/src/components/widgets/accordion.rs
+++ b/crates/dwui/src/components/widgets/accordion.rs
@@ -24,6 +24,7 @@ struct Accordion {
 
     /// Index of the panel that starts open
     #[default(None)]
+    #[into]
     initial_open: Option<usize>,
 }
 

--- a/crates/dwui/src/components/widgets/alert.rs
+++ b/crates/dwui/src/components/widgets/alert.rs
@@ -40,10 +40,12 @@ struct Alert {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     title: String,
 
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
 
     #[signal]

--- a/crates/dwui/src/components/widgets/badge.rs
+++ b/crates/dwui/src/components/widgets/badge.rs
@@ -17,6 +17,7 @@ pub enum BadgeVariant {
 struct Badge {
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
 
     #[signal]

--- a/crates/dwui/src/components/widgets/button.rs
+++ b/crates/dwui/src/components/widgets/button.rs
@@ -25,6 +25,7 @@ pub enum ButtonSize {
 struct Button {
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
     #[default(Box::new(| _: events::Click | {}))]
     on_click: dyn Fn(events::Click) -> () + 'static,

--- a/crates/dwui/src/components/widgets/drawer.rs
+++ b/crates/dwui/src/components/widgets/drawer.rs
@@ -29,6 +29,7 @@ pub enum DrawerSize {
 struct Drawer {
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
 
     #[signal]
@@ -52,6 +53,7 @@ struct Drawer {
 
     #[signal]
     #[default("Drawer".to_string())]
+    #[into]
     aria_label: String,
 }
 

--- a/crates/dwui/src/components/widgets/dropdown_menu.rs
+++ b/crates/dwui/src/components/widgets/dropdown_menu.rs
@@ -25,6 +25,7 @@ struct DropdownMenu {
     /// Trigger button text
     #[signal]
     #[default("Menu".to_string())]
+    #[into]
     label: String,
 
     #[default(Box::new(|_|{}))]

--- a/crates/dwui/src/components/widgets/modal.rs
+++ b/crates/dwui/src/components/widgets/modal.rs
@@ -73,6 +73,7 @@ pub enum ModalSize {
 struct Modal {
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
 
     #[signal]
@@ -93,6 +94,7 @@ struct Modal {
     /// Accessible name announced by screen readers when the dialog opens
     #[signal]
     #[default("Dialog".to_string())]
+    #[into]
     aria_label: String,
 }
 

--- a/crates/dwui/src/components/widgets/pagination.rs
+++ b/crates/dwui/src/components/widgets/pagination.rs
@@ -72,6 +72,7 @@ struct Pagination {
 
     #[signal]
     #[default("Pagination".to_string())]
+    #[into]
     aria_label: String,
 }
 

--- a/crates/dwui/src/components/widgets/popover.rs
+++ b/crates/dwui/src/components/widgets/popover.rs
@@ -25,10 +25,12 @@ pub enum PopoverPosition {
 struct Popover {
     #[signal]
     #[default(None)]
+    #[into]
     anchor: Option<Dom>,
 
     #[signal]
     #[default(None)]
+    #[into]
     content: Option<Dom>,
 
     #[signal]
@@ -44,6 +46,7 @@ struct Popover {
 
     #[signal]
     #[default("Popover".to_string())]
+    #[into]
     aria_label: String,
 }
 

--- a/crates/dwui/src/components/widgets/progress.rs
+++ b/crates/dwui/src/components/widgets/progress.rs
@@ -24,6 +24,7 @@ struct Progress {
     /// Accessible name for the progress bar
     #[signal]
     #[default("Progress".to_string())]
+    #[into]
     label: String,
 }
 

--- a/crates/dwui/src/components/widgets/spinner.rs
+++ b/crates/dwui/src/components/widgets/spinner.rs
@@ -22,6 +22,7 @@ struct Spinner {
     /// Accessible label announced while loading
     #[signal]
     #[default("Loading".to_string())]
+    #[into]
     label: String,
 }
 

--- a/crates/dwui/src/components/widgets/tab_list.rs
+++ b/crates/dwui/src/components/widgets/tab_list.rs
@@ -26,6 +26,7 @@ struct TabList {
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     selected: String,
 
     #[default(Box::new(|_|{}))]
@@ -34,6 +35,7 @@ struct TabList {
     /// Accessible name for the tab list
     #[signal]
     #[default("Tabs".to_string())]
+    #[into]
     aria_label: String,
 }
 

--- a/crates/dwui/src/components/widgets/tooltip.rs
+++ b/crates/dwui/src/components/widgets/tooltip.rs
@@ -22,10 +22,12 @@ pub enum TooltipPosition {
 struct Tooltip {
     #[signal]
     #[default(None)]
+    #[into]
     anchor: Option<Dom>,
 
     #[signal]
     #[default("".to_string())]
+    #[into]
     text: String,
 
     #[signal]

--- a/crates/dwui/tests/components.rs
+++ b/crates/dwui/tests/components.rs
@@ -96,7 +96,7 @@ async fn button_is_a_real_button_and_handles_clicks() {
     dominator::append_dom(
         &tc.dom_element(),
         button!({
-            .content(Some(text("Click me")))
+            .content(text("Click me"))
             .on_click(clone!(clicked => move |_| {
                 clicked.set(clicked.get() + 1);
             }))
@@ -122,7 +122,7 @@ async fn button_disabled_signal_sets_disabled_attribute() {
     dominator::append_dom(
         &tc.dom_element(),
         button!({
-            .content(Some(text("Disabled?")))
+            .content(text("Disabled?"))
             .disabled_signal(disabled.signal())
         }),
     );
@@ -144,7 +144,7 @@ async fn text_input_associates_label_with_input() {
     dominator::append_dom(
         &tc.dom_element(),
         text_input!({
-            .label("Username".to_string())
+            .label("Username")
         }),
     );
     wait_frame().await;
@@ -166,7 +166,7 @@ async fn text_input_exposes_validation_to_assistive_technology() {
     dominator::append_dom(
         &tc.dom_element(),
         text_input!({
-            .label("Email".to_string())
+            .label("Email")
             .is_valid_signal(validity.signal_cloned())
         }),
     );
@@ -200,7 +200,7 @@ async fn text_input_writes_back_to_the_value_wrapper() {
         &tc.dom_element(),
         text_input!({
             .value(value.clone())
-            .label("Greeting".to_string())
+            .label("Greeting")
         }),
     );
     wait_frames(2).await;
@@ -221,7 +221,7 @@ async fn select_associates_label_and_renders_options() {
     dominator::append_dom(
         &tc.dom_element(),
         select!({
-            .label("Fruit".to_string())
+            .label("Fruit")
             .options(vec![
                 ("a".to_string(), "Apple".to_string()),
                 ("b".to_string(), "Banana".to_string()),
@@ -249,7 +249,7 @@ async fn slider_labels_both_inputs() {
         &tc.dom_element(),
         slider!({
             .value(value.clone())
-            .label("Volume".to_string())
+            .label("Volume")
         }),
     );
     wait_frames(2).await;
@@ -277,7 +277,7 @@ async fn switch_exposes_and_toggles_state() {
         &tc.dom_element(),
         switch!({
             .checked_signal(checked.signal())
-            .label("Notifications".to_string())
+            .label("Notifications")
             .on_change(clone!(checked => move |value| {
                 checked.set(value);
             }))
@@ -317,7 +317,7 @@ async fn checkbox_exposes_and_toggles_state() {
         &tc.dom_element(),
         checkbox!({
             .checked_signal(checked.signal())
-            .label("Accept terms".to_string())
+            .label("Accept terms")
             .on_change(clone!(checked => move |value| {
                 checked.set(value);
             }))
@@ -350,7 +350,7 @@ async fn progress_exposes_value_to_assistive_technology() {
         &tc.dom_element(),
         progress!({
             .value_signal(value.signal())
-            .label("Upload progress".to_string())
+            .label("Upload progress")
         }),
     );
     wait_frame().await;
@@ -398,11 +398,11 @@ async fn modal_has_dialog_semantics_and_closes() {
         &tc.dom_element(),
         modal!({
             .open_signal(open.signal())
-            .aria_label("Example dialog".to_string())
+            .aria_label("Example dialog")
             .on_close(clone!(open => move || {
                 open.set(false);
             }))
-            .content(Some(text("Dialog body")))
+            .content(text("Dialog body"))
         }),
     );
     wait_frame().await;
@@ -435,7 +435,7 @@ async fn tab_list_follows_the_aria_tabs_pattern() {
         &tc.dom_element(),
         tab_list!({
             .selected_signal(selected.signal_cloned())
-            .aria_label("Example tabs".to_string())
+            .aria_label("Example tabs")
             .tabs(vec![
                 ("one".to_string(), "One".to_string()),
                 ("two".to_string(), "Two".to_string()),
@@ -511,7 +511,7 @@ async fn badge_renders_content() {
     dominator::append_dom(
         &tc.dom_element(),
         badge!({
-            .content(Some(text("New")))
+            .content(text("New"))
             .variant(BadgeVariant::Primary)
         }),
     );
@@ -529,14 +529,14 @@ async fn alert_roles_match_severity() {
         &tc.dom_element(),
         alert!({
             .variant(AlertVariant::Error)
-            .title("Something failed".to_string())
+            .title("Something failed")
         }),
     );
     dominator::append_dom(
         &tc.dom_element(),
         alert!({
             .variant(AlertVariant::Success)
-            .title("All good".to_string())
+            .title("All good")
         }),
     );
     wait_frame().await;
@@ -554,7 +554,7 @@ async fn alert_dismiss_hides_and_notifies() {
         &tc.dom_element(),
         alert!({
             .variant(AlertVariant::Info)
-            .title("Heads up".to_string())
+            .title("Heads up")
             .dismissible(true)
             .on_dismiss(clone!(dismissed => move || {
                 dismissed.set(true);
@@ -650,8 +650,8 @@ async fn tooltip_is_linked_and_hidden_by_default() {
     dominator::append_dom(
         &tc.dom_element(),
         tooltip!({
-            .anchor(Some(text("hover me")))
-            .text("More information".to_string())
+            .anchor(text("hover me"))
+            .text("More information")
         }),
     );
     wait_frame().await;
@@ -673,7 +673,7 @@ async fn avatar_falls_back_to_initials() {
     dominator::append_dom(
         &tc.dom_element(),
         avatar!({
-            .name("Ada Lovelace".to_string())
+            .name("Ada Lovelace")
         }),
     );
     wait_frames(2).await;
@@ -695,7 +695,7 @@ async fn avatar_renders_image_when_src_given() {
         &tc.dom_element(),
         avatar!({
             .src(Some("data:image/gif;base64,R0lGODlhAQABAAAAACw=".to_string()))
-            .name("Grace Hopper".to_string())
+            .name("Grace Hopper")
         }),
     );
     wait_frames(2).await;
@@ -755,7 +755,7 @@ async fn spinner_announces_loading() {
     dominator::append_dom(
         &tc.dom_element(),
         spinner!({
-            .label("Crunching numbers".to_string())
+            .label("Crunching numbers")
         }),
     );
     wait_frame().await;
@@ -774,7 +774,7 @@ async fn divider_is_a_separator() {
     dominator::append_dom(
         &tc.dom_element(),
         divider!({
-            .label("or".to_string())
+            .label("or")
         }),
     );
     wait_frame().await;
@@ -791,7 +791,7 @@ async fn button_sizes_set_height_classes() {
         &tc.dom_element(),
         button!({
             .size(ButtonSize::Small)
-            .content(Some(text("Small")))
+            .content(text("Small"))
         }),
     );
     wait_frame().await;
@@ -995,7 +995,7 @@ async fn date_picker_opens_a_grid_and_selects_a_day() {
     dominator::append_dom(
         &tc.dom_element(),
         date_picker!({
-            .label("Start date".to_string())
+            .label("Start date")
             .value_signal(value.signal())
             .on_change(clone!(value => move |date| {
                 value.set(Some(date));
@@ -1047,7 +1047,7 @@ async fn date_picker_navigates_months() {
     dominator::append_dom(
         &tc.dom_element(),
         date_picker!({
-            .label("Date".to_string())
+            .label("Date")
             .value_signal(value.signal())
         }),
     );
@@ -1117,10 +1117,7 @@ async fn focus_standard_replaces_the_global_reset() {
 
     let tc = TestContainer::new();
 
-    dominator::append_dom(
-        &tc.dom_element(),
-        button!({ .content(Some(text("Focus me"))) }),
-    );
+    dominator::append_dom(&tc.dom_element(), button!({ .content(text("Focus me")) }));
     wait_frame().await;
 
     assert_focusable(&tc.query("button").unwrap());
@@ -1149,8 +1146,8 @@ async fn interactive_controls_carry_the_focusable_marker() {
     dominator::append_dom(
         &tc.dom_element(),
         html!("div", {
-            .child(checkbox!({ .label("Check".to_string()) }))
-            .child(switch!({ .label("Toggle".to_string()) }))
+            .child(checkbox!({ .label("Check") }))
+            .child(switch!({ .label("Toggle") }))
         }),
     );
     wait_frame().await;
@@ -1171,7 +1168,7 @@ async fn field_reserves_error_space_and_keeps_height() {
     dominator::append_dom(
         &tc.dom_element(),
         text_input!({
-            .label("Email".to_string())
+            .label("Email")
             .is_valid_signal(validity.signal_cloned())
         }),
     );
@@ -1209,16 +1206,16 @@ async fn text_input_and_select_support_disabled() {
         &tc.dom_element(),
         html!("div", {
             .child(text_input!({
-                .label("Name".to_string())
+                .label("Name")
                 .disabled_signal(disabled.signal())
             }))
             .child(select!({
-                .label("Fruit".to_string())
+                .label("Fruit")
                 .disabled_signal(disabled.signal())
                 .options(vec![("a".to_string(), "Apple".to_string())])
             }))
             .child(slider!({
-                .label("Volume".to_string())
+                .label("Volume")
                 .disabled_signal(disabled.signal())
             }))
         }),
@@ -1253,7 +1250,7 @@ async fn text_area_syncs_value_and_reports_invalid() {
         &tc.dom_element(),
         text_area!({
             .value(value.clone())
-            .label("Bio".to_string())
+            .label("Bio")
             .rows(6u32)
             .is_valid_signal(validity.signal_cloned())
         }),
@@ -1302,9 +1299,9 @@ async fn number_input_steps_and_clamps() {
         &tc.dom_element(),
         number_input!({
             .value(value.clone())
-            .label("Amount".to_string())
-            .min(Some(0.0))
-            .max(Some(6.0))
+            .label("Amount")
+            .min(0.0)
+            .max(6.0)
             .step(2.0)
         }),
     );
@@ -1345,7 +1342,7 @@ async fn radio_group_selection_and_roving_tabindex() {
     dominator::append_dom(
         &tc.dom_element(),
         radio_group!({
-            .label("Flavor".to_string())
+            .label("Flavor")
             .value_signal(value.signal_cloned())
             .options(vec![
                 ("a".to_string(), "Almond".to_string()),
@@ -1417,7 +1414,7 @@ async fn slider_chrome_tracks_fill_percentage() {
         &tc.dom_element(),
         slider!({
             .value(value.clone())
-            .label("Volume".to_string())
+            .label("Volume")
             .min(0.0f32)
             .max(100.0f32)
         }),
@@ -1449,8 +1446,8 @@ async fn checkbox_and_switch_use_the_on_accent_token() {
     dominator::append_dom(
         &tc.dom_element(),
         html!("div", {
-            .child(checkbox!({ .checked(true) .label("Check".to_string()) }))
-            .child(switch!({ .checked(true) .label("Toggle".to_string()) }))
+            .child(checkbox!({ .checked(true) .label("Check") }))
+            .child(switch!({ .checked(true) .label("Toggle") }))
         }),
     );
     wait_frames(2).await;
@@ -1536,10 +1533,10 @@ async fn modal_traps_tab_focus() {
         &tc.dom_element(),
         modal!({
             .open(true)
-            .aria_label("Trap test".to_string())
-            .content(Some(html!("div", {
+            .aria_label("Trap test")
+            .content(html!("div", {
                 .child(html!("button", { .attr("id", "trap-inner") .text("Inner") }))
-            })))
+            }))
         }),
     );
     wait_frames(2).await;
@@ -1589,7 +1586,7 @@ async fn alert_dismiss_button_is_an_icon_with_a_label() {
     dominator::append_dom(
         &tc.dom_element(),
         alert!({
-            .title("Closable".to_string())
+            .title("Closable")
             .dismissible(true)
         }),
     );
@@ -1655,7 +1652,7 @@ async fn dropdown_menu_opens_selects_and_closes() {
     dominator::append_dom(
         &tc.dom_element(),
         dropdown_menu!({
-            .label("Actions".to_string())
+            .label("Actions")
             .items(vec![
                 ("copy".to_string(), "Copy".to_string(), false),
                 ("paste".to_string(), "Paste".to_string(), true),
@@ -1698,8 +1695,8 @@ async fn popover_opens_and_closes_on_escape() {
         &tc.dom_element(),
         popover!({
             .open_signal(open.signal())
-            .anchor(Some(html!("button", { .attr("id", "pop-trigger") .text("Open") })))
-            .content(Some(text("Popover body")))
+            .anchor(html!("button", { .attr("id", "pop-trigger") .text("Open") }))
+            .content(text("Popover body"))
             .on_close(clone!(open => move || {
                 open.set(false);
             }))
@@ -1746,8 +1743,8 @@ async fn drawer_opens_from_a_side_and_closes() {
         drawer!({
             .open_signal(open.signal())
             .side(DrawerSide::Left)
-            .aria_label("Settings".to_string())
-            .content(Some(text("Drawer body")))
+            .aria_label("Settings")
+            .content(text("Drawer body"))
             .on_close(clone!(open => move || {
                 open.set(false);
             }))
@@ -1841,7 +1838,7 @@ async fn select_popup_is_theme_colored() {
     dominator::append_dom(
         &tc.dom_element(),
         select!({
-            .label("Fruit".to_string())
+            .label("Fruit")
             .options(vec![("a".to_string(), "Apple".to_string())])
         }),
     );

--- a/examples/webpage/src/pages/components_page.rs
+++ b/examples/webpage/src/pages/components_page.rs
@@ -45,7 +45,7 @@ pub fn components_page() -> Dom {
             .dwclass!("flex align-items-center gap-4 m-t-6 m-b-4")
             .child(switch!({
                 .checked_signal(is_light.signal())
-                .label("Light theme preview".to_string())
+                .label("Light theme preview")
                 .on_change(clone!(is_light => move |checked| {
                     is_light.set(checked);
                 }))
@@ -127,8 +127,8 @@ fn section_card(title: &str, description: &str, demo: Dom, source: Dom) -> Dom {
         .scheme(ColorScheme::Void)
         .padding(CardPadding::Large)
         .apply(crate::fx::spotlight)
-        .apply(move |b| {
-            dwclass!(b, "flex flex-col gap-4")
+        .content(html!("div", {
+            .dwclass!("flex flex-col gap-4")
             .child(heading!({
                 .content(text(&title))
                 .text_size(TextSize::Large)
@@ -140,7 +140,7 @@ fn section_card(title: &str, description: &str, demo: Dom, source: Dom) -> Dom {
             }))
             .child(demo)
             .child(source)
-        })
+        }))
     })
 }
 
@@ -150,15 +150,15 @@ fn buttons_demo() -> Dom {
         .dwclass!("flex flex-col gap-4")
         .children([
             button!({
-                .content(Some(text("Primary Flat")))
+                .content(text("Primary Flat"))
             }),
             button!({
                 .button_type(ButtonType::Border)
-                .content(Some(text("Primary Border")))
+                .content(text("Primary Border"))
             }),
             button!({
                 .button_type(ButtonType::Text)
-                .content(Some(text("Text Button")))
+                .content(text("Text Button"))
             }),
             html!("div", {
                 .dwclass!("flex flex-row gap-4 align-items-center")
@@ -166,20 +166,20 @@ fn buttons_demo() -> Dom {
                     .dwclass!("grow")
                     .child(button!({
                         .size(ButtonSize::Small)
-                        .content(Some(text("Small")))
+                        .content(text("Small"))
                     }))
                 }))
                 .child(html!("div", {
                     .dwclass!("grow")
                     .child(button!({
                         .size(ButtonSize::Large)
-                        .content(Some(text("Large")))
+                        .content(text("Large"))
                     }))
                 }))
             }),
             button!({
                 .disabled(true)
-                .content(Some(text("Disabled")))
+                .content(text("Disabled"))
             }),
         ])
     })
@@ -191,23 +191,23 @@ fn badges_demo() -> Dom {
         .dwclass!("flex flex-row flex-wrap gap-4 align-items-center")
         .children([
             badge!({
-                .content(Some(text("Primary")))
+                .content(text("Primary"))
                 .variant(BadgeVariant::Primary)
             }),
             badge!({
-                .content(Some(text("Error")))
+                .content(text("Error"))
                 .variant(BadgeVariant::Error)
             }),
             badge!({
-                .content(Some(text("Void")))
+                .content(text("Void"))
                 .variant(BadgeVariant::Void)
             }),
             badge!({
-                .content(Some(text("Outline")))
+                .content(text("Outline"))
                 .variant(BadgeVariant::Outline)
             }),
             badge!({
-                .content(Some(text("99+")))
+                .content(text("99+"))
                 .variant(BadgeVariant::Error)
             }),
         ])
@@ -221,22 +221,22 @@ fn alerts_demo() -> Dom {
         .children([
             alert!({
                 .variant(AlertVariant::Info)
-                .title("Heads up".to_string())
-                .content(Some(text("A new version of dwui is available.")))
+                .title("Heads up")
+                .content(text("A new version of dwui is available."))
             }),
             alert!({
                 .variant(AlertVariant::Success)
-                .title("Deployed".to_string())
-                .content(Some(text("Build #214 went live without warnings.")))
+                .title("Deployed")
+                .content(text("Build #214 went live without warnings."))
             }),
             alert!({
                 .variant(AlertVariant::Warning)
-                .title("Heavy load".to_string())
+                .title("Heavy load")
             }),
             alert!({
                 .variant(AlertVariant::Error)
-                .title("Build failed".to_string())
-                .content(Some(text("Use the dismiss button to close this alert.")))
+                .title("Build failed")
+                .content(text("Use the dismiss button to close this alert."))
                 .dismissible(true)
             }),
         ])
@@ -252,11 +252,11 @@ fn inputs_demo() -> Dom {
         .children([
             text_input!({
                 .value(value.clone())
-                .label("Your name".to_string())
+                .label("Your name")
             }),
             text_input!({
                 .input_type(TextInputType::Password)
-                .label("Password".to_string())
+                .label("Password")
             }),
             text_input!({
                 .value(value.clone())
@@ -267,12 +267,12 @@ fn inputs_demo() -> Dom {
                         ValidationResult::Invalid { message: "Give me bananas!".to_string() }
                     }
                 }))
-                .label("Accepts bananas".to_string())
+                .label("Accepts bananas")
             }),
             text_input!({
                 .value(Mutable::new("Read only".to_string()))
                 .disabled(true)
-                .label("Disabled".to_string())
+                .label("Disabled")
             }),
         ])
     })
@@ -288,14 +288,14 @@ fn text_area_number_demo() -> Dom {
         .children([
             text_area!({
                 .value(bio.clone())
-                .label("Short bio".to_string())
+                .label("Short bio")
                 .rows(3u32)
             }),
             number_input!({
                 .value(amount.clone())
-                .label("Quantity".to_string())
-                .min(Some(0.0))
-                .max(Some(10.0))
+                .label("Quantity")
+                .min(0.0)
+                .max(10.0)
                 .step(1.0)
             }),
         ])
@@ -310,7 +310,7 @@ fn radio_group_demo() -> Dom {
     html!("div", {
         .dwclass!("flex flex-col gap-6")
         .child(radio_group!({
-            .label("Flavor".to_string())
+            .label("Flavor")
             .value_signal(flavor.signal_cloned())
             .options(vec![
                 ("almond".to_string(), "Almond".to_string()),
@@ -320,7 +320,7 @@ fn radio_group_demo() -> Dom {
             .on_change(clone!(flavor => move |key| flavor.set(key)))
         }))
         .child(radio_group!({
-            .label("Release channel".to_string())
+            .label("Release channel")
             .direction(RadioGroupDirection::Horizontal)
             .value_signal(channel.signal_cloned())
             .options(vec![
@@ -340,7 +340,7 @@ fn dropdown_menu_demo() -> Dom {
     html!("div", {
         .dwclass!("flex flex-col gap-4 align-items-start")
         .child(dropdown_menu!({
-            .label("Actions".to_string())
+            .label("Actions")
             .items(vec![
                 ("copy".to_string(), "Copy link".to_string(), false),
                 ("rename".to_string(), "Rename".to_string(), false),
@@ -395,7 +395,7 @@ fn toasts_demo() -> Dom {
         .child(button!({
             .button_type(ButtonType::Border)
             .size(ButtonSize::Small)
-            .content(Some(text("Success toast")))
+            .content(text("Success toast"))
             .on_click(clone!(toaster => move |_| {
                 toaster.success("Saved to workspace");
             }))
@@ -403,7 +403,7 @@ fn toasts_demo() -> Dom {
         .child(button!({
             .button_type(ButtonType::Border)
             .size(ButtonSize::Small)
-            .content(Some(text("Sticky error")))
+            .content(text("Sticky error"))
             .on_click(clone!(toaster => move |_| {
                 toaster.push(ToastOptions {
                     title: "Build failed".to_string(),
@@ -482,7 +482,7 @@ fn drawer_demo() -> Dom {
         .dwclass!("flex flex-row gap-4")
         .child(button!({
             .button_type(ButtonType::Border)
-            .content(Some(text("Open right drawer")))
+            .content(text("Open right drawer"))
             .on_click(clone!(open, side => move |_| {
                 side.set(DrawerSide::Right);
                 open.set(true);
@@ -490,7 +490,7 @@ fn drawer_demo() -> Dom {
         }))
         .child(button!({
             .button_type(ButtonType::Border)
-            .content(Some(text("Open left drawer")))
+            .content(text("Open left drawer"))
             .on_click(clone!(open, side => move |_| {
                 side.set(DrawerSide::Left);
                 open.set(true);
@@ -499,9 +499,9 @@ fn drawer_demo() -> Dom {
         .child(drawer!({
             .open_signal(open.signal())
             .side_signal(side.signal())
-            .aria_label("Demo drawer".to_string())
+            .aria_label("Demo drawer")
             .on_close(clone!(open => move || open.set(false)))
-            .content(Some(html!("div", {
+            .content(html!("div", {
                 .dwclass!("flex flex-col gap-3 m-t-8")
                 .child(heading!({
                     .content(text("Drawer"))
@@ -512,7 +512,7 @@ fn drawer_demo() -> Dom {
                     .dwclass!("text-sm m-0")
                     .text("Escape closes it, Tab stays trapped inside, and the scrim click dismisses.")
                 }))
-            })))
+            }))
         }))
     })
 }
@@ -526,7 +526,7 @@ fn select_slider_demo() -> Dom {
         .dwclass!("flex flex-col gap-4")
         .children([
             select!({
-                .label("Favourite option".to_string())
+                .label("Favourite option")
                 .value(selected.clone())
                 .options(vec![
                     ("a".to_string(), "Option A".to_string()),
@@ -536,7 +536,7 @@ fn select_slider_demo() -> Dom {
             }),
             slider!({
                 .value(amount.clone())
-                .label("Amount".to_string())
+                .label("Amount")
             }),
         ])
     })
@@ -553,22 +553,22 @@ fn toggles_demo() -> Dom {
         .children([
             switch!({
                 .checked_signal(notifications.signal())
-                .label("Enable notifications".to_string())
+                .label("Enable notifications")
                 .on_change(clone!(notifications => move |v| notifications.set(v)))
             }),
             switch!({
                 .checked(false)
                 .disabled(true)
-                .label("Disabled switch".to_string())
+                .label("Disabled switch")
             }),
             checkbox!({
                 .checked_signal(newsletter.signal())
-                .label("Subscribe to newsletter".to_string())
+                .label("Subscribe to newsletter")
                 .on_change(clone!(newsletter => move |v| newsletter.set(v)))
             }),
             checkbox!({
                 .checked_signal(terms.signal())
-                .label("Accept the terms".to_string())
+                .label("Accept the terms")
                 .on_change(clone!(terms => move |v| terms.set(v)))
             }),
         ])
@@ -584,15 +584,15 @@ fn progress_demo() -> Dom {
         .children([
             progress!({
                 .value_signal(value.signal().map(|v| v as f64))
-                .label("Demo progress".to_string())
+                .label("Demo progress")
             }),
             progress!({
                 .indeterminate(true)
-                .label("Indeterminate progress".to_string())
+                .label("Indeterminate progress")
             }),
             slider!({
                 .value(value.clone())
-                .label("Drag to set progress".to_string())
+                .label("Drag to set progress")
             }),
             html!("div", {
                 .dwclass!("flex flex-row gap-4 align-items-center")
@@ -617,14 +617,14 @@ fn avatar_skeleton_demo() -> Dom {
         .child(html!("div", {
             .dwclass!("flex flex-row gap-3 align-items-center")
             .child(avatar!({
-                .name("Ada Lovelace".to_string())
+                .name("Ada Lovelace")
                 .size(AvatarSize::Small)
             }))
             .child(avatar!({
-                .name("Grace Hopper".to_string())
+                .name("Grace Hopper")
             }))
             .child(avatar!({
-                .name("Alan Turing".to_string())
+                .name("Alan Turing")
                 .size(AvatarSize::Large)
             }))
         }))
@@ -657,32 +657,32 @@ fn tooltip_divider_demo() -> Dom {
         .child(html!("div", {
             .dwclass!("flex flex-row gap-4 justify-center")
             .child(tooltip!({
-                .text("Tooltips appear on hover and focus".to_string())
+                .text("Tooltips appear on hover and focus")
                 .position(TooltipPosition::Top)
-                .anchor(Some(html!("div", {
+                .anchor(html!("div", {
                     .dwclass!("w-32")
                     .child(button!({
                         .button_type(ButtonType::Border)
                         .size(ButtonSize::Small)
-                        .content(Some(text("Hover me")))
+                        .content(text("Hover me"))
                     }))
-                })))
+                }))
             }))
             .child(tooltip!({
-                .text("This one sits below".to_string())
+                .text("This one sits below")
                 .position(TooltipPosition::Bottom)
-                .anchor(Some(html!("div", {
+                .anchor(html!("div", {
                     .dwclass!("w-32")
                     .child(button!({
                         .button_type(ButtonType::Border)
                         .size(ButtonSize::Small)
-                        .content(Some(text("Or me")))
+                        .content(text("Or me"))
                     }))
-                })))
+                }))
             }))
         }))
         .child(divider!({
-            .label("or".to_string())
+            .label("or")
         }))
         .child(divider!({}))
     })
@@ -718,7 +718,7 @@ fn tabs_demo() -> Dom {
         .dwclass!("flex flex-col gap-4")
         .child(tab_list!({
             .selected_signal(selected.signal_cloned())
-            .aria_label("Tabs demo".to_string())
+            .aria_label("Tabs demo")
             .tabs(vec![
                 ("overview".to_string(), "Overview".to_string()),
                 ("features".to_string(), "Features".to_string()),
@@ -746,7 +746,7 @@ fn tabs_demo() -> Dom {
 #[example_html(themes = ["base16-ocean.dark"])]
 fn accordion_demo() -> Dom {
     accordion!({
-        .initial_open(Some(0))
+        .initial_open(0)
         .items(vec![
             (
                 "What is dwui?".to_string(),
@@ -858,7 +858,7 @@ fn virtual_scroll_demo() -> Dom {
         .item_count_signal(count.signal())
         .item_height(36.0)
         .height(320.0)
-        .aria_label("Virtual scroll demo".to_string())
+        .aria_label("Virtual scroll demo")
         .loading_signal(loading.signal())
         .render_item(Box::new(|index: usize| {
             html!("div", {
@@ -899,14 +899,14 @@ fn date_picker_demo() -> Dom {
     html!("div", {
         .dwclass!("flex flex-col gap-4")
         .child(date_picker!({
-            .label("Start date".to_string())
+            .label("Start date")
             .value_signal(start.signal())
             .on_change(clone!(start => move |date| {
                 start.set(Some(date));
             }))
         }))
         .child(date_picker!({
-            .label("End date".to_string())
+            .label("End date")
             .value_signal(end.signal())
             .on_change(clone!(end => move |date| {
                 end.set(Some(date));

--- a/examples/webpage/src/pages/docs/doc_pages/animations.rs
+++ b/examples/webpage/src/pages/docs/doc_pages/animations.rs
@@ -97,7 +97,7 @@ fn animation_examples() -> Dom {
                         }))
                         .content(html!("span", {
                             .text("Toggle spinning")
-                        }).into())
+                        }))
                     }),
                     html!("div", {
                         .dwclass!("w-8 h-8 bg-red-500")
@@ -118,7 +118,7 @@ fn animation_examples() -> Dom {
                         }))
                         .content(html!("span", {
                             .text("Toggle ping")
-                        }).into())
+                        }))
                     }),
                     html!("div", {
                         .dwclass!("w-8 h-8 bg-red-500")
@@ -139,7 +139,7 @@ fn animation_examples() -> Dom {
                         }))
                         .content(html!("span", {
                             .text("Toggle pulse")
-                        }).into())
+                        }))
                     }),
                     html!("div", {
                         .dwclass!("w-8 h-8 bg-red-500")
@@ -160,7 +160,7 @@ fn animation_examples() -> Dom {
                         }))
                         .content(html!("span", {
                             .text("Toggle bounce")
-                        }).into())
+                        }))
                     }),
                     html!("div", {
                         .dwclass!("w-8 h-8 bg-red-500")

--- a/examples/webpage/src/pages/docs/doc_pages/getting_started.rs
+++ b/examples/webpage/src/pages/docs/doc_pages/getting_started.rs
@@ -89,7 +89,7 @@ fn dwui_hello() -> Dom {
         .dwclass!("flex flex-col gap-4 w-full p-2")
         .child(switch!({
             .checked_signal(enabled.signal())
-            .label("Reactive demo".to_string())
+            .label("Reactive demo")
             .on_change({
                 let enabled = enabled.clone();
                 move |value| enabled.set(value)
@@ -98,7 +98,7 @@ fn dwui_hello() -> Dom {
         .child_signal(enabled.signal().map(|on| {
             Some(badge!({
                 .variant(if on { BadgeVariant::Primary } else { BadgeVariant::Void })
-                .content(Some(text(if on { "signal: true" } else { "signal: false" })))
+                .content(text(if on { "signal: true" } else { "signal: false" }))
             }))
         }))
     })

--- a/examples/webpage/src/pages/dwui/example_small.rs
+++ b/examples/webpage/src/pages/dwui/example_small.rs
@@ -12,8 +12,9 @@ pub fn example_card_modal() -> Dom {
 
     card!({
         .scheme(ColorScheme::Void)
-        .apply(clone!(show_modal, show_modal_small => move |b| {
-            dwclass!(b, "w-64 flex-initial flex flex-col gap-4")
+        .apply(|b| dwclass!(b, "w-64 flex-initial"))
+        .content(html!("div", {
+            .dwclass!("flex flex-col gap-4")
             .children([
                 heading!({
                     .content(text("Modal Example"))
@@ -22,7 +23,7 @@ pub fn example_card_modal() -> Dom {
                 }),
                 button!({
                     .apply(|b| dwclass!(b, "w-full"))
-                    .content(Some(text("Open Large Modal")))
+                    .content(text("Open Large Modal"))
                     .on_click(clone!(show_modal => move |_: events::Click| {
                         show_modal.set(true);
                     }))
@@ -30,7 +31,7 @@ pub fn example_card_modal() -> Dom {
                 button!({
                     .apply(|b| dwclass!(b, "w-full"))
                     .button_type(ButtonType::Border)
-                    .content(Some(text("Open Small Modal")))
+                    .content(text("Open Small Modal"))
                     .on_click(clone!(show_modal_small => move |_: events::Click| {
                         show_modal_small.set(true);
                     }))
@@ -38,11 +39,11 @@ pub fn example_card_modal() -> Dom {
                 modal!({
                     .open_signal(show_modal.signal())
                     .size(ModalSize::Large)
-                    .aria_label("Large modal example".to_string())
+                    .aria_label("Large modal example")
                     .on_close(clone!(show_modal => move || {
                         show_modal.set(false);
                     }))
-                    .content(Some(html!("div", {
+                    .content(html!("div", {
                         .dwclass!("flex flex-col gap-4")
                         .children([
                             heading!({
@@ -54,22 +55,22 @@ pub fn example_card_modal() -> Dom {
                                 .text("This is a large modal dialog (900px wide). You can close it by clicking the X button, clicking outside, or pressing Escape.")
                             }),
                             button!({
-                                .content(Some(text("Close Modal")))
+                                .content(text("Close Modal"))
                                 .on_click(clone!(show_modal => move |_: events::Click| {
                                     show_modal.set(false);
                                 }))
                             })
                         ])
-                    })))
+                    }))
                 }),
                 modal!({
                     .open_signal(show_modal_small.signal())
                     .size(ModalSize::Small)
-                    .aria_label("Small modal example".to_string())
+                    .aria_label("Small modal example")
                     .on_close(clone!(show_modal_small => move || {
                         show_modal_small.set(false);
                     }))
-                    .content(Some(html!("div", {
+                    .content(html!("div", {
                         .dwclass!("flex flex-col gap-4")
                         .children([
                             heading!({
@@ -81,13 +82,13 @@ pub fn example_card_modal() -> Dom {
                                 .text("This is a small modal dialog (24rem wide).")
                             }),
                             button!({
-                                .content(Some(text("Close Modal")))
+                                .content(text("Close Modal"))
                                 .on_click(clone!(show_modal_small => move |_: events::Click| {
                                     show_modal_small.set(false);
                                 }))
                             })
                         ])
-                    })))
+                    }))
                 })
             ])
         }))

--- a/examples/webpage/src/pages/home.rs
+++ b/examples/webpage/src/pages/home.rs
@@ -72,7 +72,7 @@ fn hero() -> Dom {
                         .apply(magnetic(7.0))
                         .child(button!({
                             .apply(|b| dwclass!(b, "w-full"))
-                            .content(Some(text("Get started")))
+                            .content(text("Get started"))
                             .on_click(|_: events::Click| {
                                 go_to_url("#/docs/getting-started");
                             })
@@ -84,7 +84,7 @@ fn hero() -> Dom {
                         .child(button!({
                             .apply(|b| dwclass!(b, "w-full"))
                             .button_type(ButtonType::Border)
-                            .content(Some(text("Components")))
+                            .content(text("Components"))
                             .on_click(|_: events::Click| {
                                 go_to_url("#/components");
                             })
@@ -319,7 +319,7 @@ fn bento_tile_reactive() -> Dom {
                 .dwclass!("flex flex-col gap-3 m-t-2")
                 .child(switch!({
                     .checked_signal(enabled.signal())
-                    .label("Live demo".to_string())
+                    .label("Live demo")
                     .on_change({
                         let enabled = enabled.clone();
                         move |v| enabled.set(v)
@@ -328,7 +328,7 @@ fn bento_tile_reactive() -> Dom {
                 .child_signal(enabled.signal().map(|on| {
                     Some(badge!({
                         .variant(if on { BadgeVariant::Primary } else { BadgeVariant::Void })
-                        .content(Some(text(if on { "signal: true" } else { "signal: false" })))
+                        .content(text(if on { "signal: true" } else { "signal: false" }))
                     }))
                 }))
             }),
@@ -400,18 +400,18 @@ fn components_preview() -> Dom {
             .children([
                 preview_card("inputs", vec![
                     text_input!({
-                        .label("Project name".to_string())
+                        .label("Project name")
                     }),
                     slider!({
                         .value(progress_value.clone())
-                        .label("Threshold".to_string())
+                        .label("Threshold")
                     }),
                 ]),
                 preview_card("feedback", vec![
                     alert!({
                         .variant(AlertVariant::Success)
-                        .title("Deployed".to_string())
-                        .content(Some(text("Build #214 is live.")))
+                        .title("Deployed")
+                        .content(text("Build #214 is live."))
                     }),
                     html!("div", {
                         .dwclass!("flex flex-row gap-4 align-items-center")
@@ -420,7 +420,7 @@ fn components_preview() -> Dom {
                         }))
                         .child(progress!({
                             .value_signal(progress_value.signal().map(|v| v as f64))
-                            .label("Demo progress".to_string())
+                            .label("Demo progress")
                         }))
                     }),
                 ]),
@@ -428,14 +428,14 @@ fn components_preview() -> Dom {
                     html!("div", {
                         .dwclass!("flex flex-row gap-3 align-items-center")
                         .child(avatar!({
-                            .name("Ada Lovelace".to_string())
+                            .name("Ada Lovelace")
                         }))
                         .child(avatar!({
-                            .name("Grace Hopper".to_string())
+                            .name("Grace Hopper")
                         }))
                         .child(badge!({
                             .variant(BadgeVariant::Outline)
-                            .content(Some(text("v0.10.0")))
+                            .content(text("v0.10.0"))
                         }))
                     }),
                     breadcrumbs!({
@@ -456,7 +456,7 @@ fn components_preview() -> Dom {
                 .child(button!({
                     .apply(|b| dwclass!(b, "w-full"))
                     .button_type(ButtonType::Border)
-                    .content(Some(text("Browse all components →")))
+                    .content(text("Browse all components →"))
                     .on_click(|_: events::Click| {
                         go_to_url("#/components");
                     })
@@ -513,7 +513,7 @@ fn final_cta() -> Dom {
                     .apply(magnetic(7.0))
                     .child(button!({
                         .apply(|b| dwclass!(b, "w-full"))
-                        .content(Some(text("Read the docs")))
+                        .content(text("Read the docs"))
                         .on_click(|_: events::Click| {
                             go_to_url("#/docs/getting-started");
                         })
@@ -525,7 +525,7 @@ fn final_cta() -> Dom {
                     .child(button!({
                         .apply(|b| dwclass!(b, "w-full"))
                         .button_type(ButtonType::Border)
-                        .content(Some(text("Open the gallery")))
+                        .content(text("Open the gallery"))
                         .on_click(|_: events::Click| {
                             go_to_url("#/components");
                         })

--- a/examples/webpage/src/pages/signal_lab.rs
+++ b/examples/webpage/src/pages/signal_lab.rs
@@ -206,19 +206,19 @@ fn controls(
         }))
         .child(slider!({
             .value(spread.clone())
-            .label("spread".to_string())
+            .label("spread")
         }))
         .child(slider!({
             .value(twist.clone())
-            .label("twist".to_string())
+            .label("twist")
         }))
         .child(slider!({
             .value(glow.clone())
-            .label("glow".to_string())
+            .label("glow")
         }))
         .child(switch!({
             .checked_signal(stacked.signal())
-            .label("fan out".to_string())
+            .label("fan out")
             .on_change(clone!(stacked => move |v| stacked.set(v)))
         }))
     })


### PR DESCRIPTION
## Summary

Adopts [futures-signals-component-macro 0.5.0](https://github.com/JedimEmO/futures-signals-component-macro/pull/9) across dwui and the webpage. Depends on that PR — see the merge checklist below.

### Required props, enforced at compile time
`card.content`, `heading.content`, and `virtual_scroll.render_item` are now `#[required]`. Omitting them was previously a silent empty render (or a placeholder `div` for the virtual scroller); it is now a targeted compile error:

```
error[E0277]: missing required props for component `card`
   | required props: `content` — set each with `.content(...)`
```

The enforcement immediately caught two real bugs: `card!` call sites in `components_page.rs` and `example_small.rs` that injected children through `.apply()` and never set content — both now pass real content nodes.

### `#[into]` ergonomics
All `Option<Dom>`, `String`, and optional-scalar props across 26 components take `impl Into<T>` now. Call-site cleanup: 50 `.content(Some(...))` → `.content(...)`, 86 literal `.to_string()` args dropped, and the four `.content(html!(...).into())` sites that would have become ambiguous pass the `Dom` directly.

### Spotlight bug fixed by composed `apply`
`section_card` calls `.apply(crate::fx::spotlight)` followed by a second `.apply(...)`; under 0.4 the second call silently discarded the first, so the gallery spotlight effect was dead code. With composing apply it works again — verified in headless Chrome: all 24 section cards carry the `--sx/--sy` spotlight vars on hover, layout is unchanged, zero console errors, and the restructured modal example opens with its focus trap intact.

Render-fn `apply` handling is untouched (the prop keeps its `Option<Box<dyn FnOnce>>` type) — dwui compiled with **zero source edits** against the new macro before any of this adoption, which was verified explicitly.

## Test plan

- [x] `cargo check --workspace --all-targets`, `cargo test` (native)
- [x] `wasm-pack test --headless --firefox crates/dwui` — 51 component + 19 styling browser tests green
- [x] `cargo clippy` — zero new warnings vs baseline; `cargo fmt --check` at exact parity with pre-existing state
- [x] `trunk build` + headless-Chrome visual verification of the components page (spotlight vars, layout, modal open/close)
- [x] `cargo doc -p dwui` — generated macro doc tables now mark `[required]` and `impl Into<T>` setters

## Merge checklist

- [ ] Land JedimEmO/futures-signals-component-macro#9, tag `v0.5.0`, publish to crates.io
- [ ] Drop the temporary `[patch.crates-io]` path override from the root `Cargo.toml` (CI cannot resolve the local path; this PR stays draft until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)